### PR TITLE
Feat/refactor top contributor

### DIFF
--- a/src/honeyPots/index.ts
+++ b/src/honeyPots/index.ts
@@ -1,11 +1,11 @@
-import {HoneyPot__factory} from "../types/typechain-types/factories/contracts/core/HoneyPot__factory"
-import {HoneyPotFactory__factory} from "../types/typechain-types/factories/contracts/fatories/HoneyPotFactory__factory"
-import {ADDRESSES, OPERATOR} from "../libs/constants"
-import {CMetadata, SupportedChains, TransactionResponse} from "../types/types"
+import { HoneyPot__factory } from "../types/typechain-types/factories/contracts/core/HoneyPot__factory"
+import { HoneyPotFactory__factory } from "../types/typechain-types/factories/contracts/fatories/HoneyPotFactory__factory"
+import { ADDRESSES, OPERATOR } from "../libs/constants"
+import { CMetadata, SupportedChains, TransactionResponse } from "../types/types"
 import { ethers } from "ethers";
-import {AppConfig} from "../config"
+import { AppConfig } from "../config"
 import { Transaction } from "@biconomy/core-types"
-import {buildUserOperation} from "../libs/userOp"
+import { buildUserOperation } from "../libs/userOp"
 import * as ethers5 from 'ethers5';
 import * as pimlicoBundler from "../libs/bundlers/pimlico"
 import * as biconomyBundler from "../libs/bundlers/biconomy"
@@ -15,32 +15,32 @@ import { requireSupportedChain } from "../libs/utils";
 export class HoneyPot {
 
     // get honeyPot address
-    public static async get(caller: ethers5.providers.Web3Provider, salt : ethers.BigNumberish) {
+    public static async get(caller: ethers5.providers.Web3Provider, salt: ethers.BigNumberish) {
         try {
             requireSupportedChain((await caller.getNetwork()).chainId);
             const signer = caller.getSigner();
-    
+
             // Get honeyPot factory
             const hFactory = await this.getHoneyPotFactory(signer);
 
             // Get honeyPot address
             const honeyPot = await hFactory.getHoneyPot(OPERATOR, ethers.toBigInt(salt));
-            
-            return {honeyPot, salt}
+
+            return { honeyPot, salt }
         } catch (error) {
             console.log("error get honeyPot >>>> ", error)
             throw error;
-            
+
         }
-    
+
     }
 
     // create honeyPot contract
-    public static async create(caller: ethers5.providers.Web3Provider, salt : ethers.BigNumberish) {
+    public static async create(caller: ethers5.providers.Web3Provider, salt: ethers.BigNumberish) {
         try {
             requireSupportedChain((await caller.getNetwork()).chainId);
             const signer = caller.getSigner();
-    
+
             // Get honeyPot factory
             const hFactory = await this.getHoneyPotFactory(signer);
 
@@ -49,15 +49,16 @@ export class HoneyPot {
             // create honeyPot
             const tx = await hFactory.createHoneyPot(OPERATOR, ethers.toBigInt(salt));
             await tx.wait();
-            
-            return {honeyPot, salt, tx:
+
+            return {
+                honeyPot, salt, tx:
                 {
-                txHash: tx.hash,
-                status: (tx.confirmations > 1)? "success" : "pending",
-                userOpHash: ""
+                    txHash: tx.hash,
+                    status: (tx.confirmations > 1) ? "success" : "pending",
+                    userOpHash: ""
                 }
             }
-            
+
         } catch (error) {
             console.log("error create honeyPot >>>> ", error)
             throw error;
@@ -65,33 +66,34 @@ export class HoneyPot {
     }
 
     // setTopContributor in honeyPot contract
-    public static async setTopContributor(caller: ethers5.providers.Web3Provider, honeyPotAddress: string, topContributor: string) : Promise<TransactionResponse> {
+    public static async setTopContributor(privateKey: string, honeyPotAddress: string, topContributor: string): Promise<TransactionResponse> {
         try {
-            requireSupportedChain((await caller.getNetwork()).chainId);
-            const signer = caller.getSigner();
-    
+            // Create an ethers wallet from the private key
+            const wallet = new ethers.Wallet(privateKey);
+
             // Get honeyPot contract
-            const honeyPot = new ethers5.Contract(honeyPotAddress, HoneyPot__factory.abi, signer)
-            const tx = await honeyPot.setTopContributor(topContributor);
-            await tx.wait();
-            
+            const honeyPot = new HoneyPot__factory(wallet).attach(honeyPotAddress);
+
+            // Call setTopContributor and sign the transaction
+            const tx = await honeyPot.setTopContributor(topContributor).connect(wallet).wait();
+
             return {
                 txHash: tx.hash,
-                status: (tx.confirmations > 1)? "success" : "pending",
+                status: (tx.confirmations > 1) ? "success" : "pending",
                 userOpHash: ""
-            }
-            
+            };
+
         } catch (error) {
-            console.log("error setTopContributor >>>> ", error)
+            console.log("error setTopContributor >>>> ", error);
             throw error;
         }
     }
 
     // sendReward in honeyPot contract
-    public static async sendReward(caller: ethers5.providers.Web3Provider, cMetadata:CMetadata, honeyPots: string[]) {
+    public static async sendReward(caller: ethers5.providers.Web3Provider, cMetadata: CMetadata, honeyPots: string[]) {
         try {
             requireSupportedChain((await caller.getNetwork()).chainId);
-            let userOpTx:Transaction[] = []
+            let userOpTx: Transaction[] = []
             const signer = caller.getSigner();
 
             const sendRewardCallData = this.getSendRewardCallData();
@@ -99,17 +101,17 @@ export class HoneyPot {
             for (const honeyPot of honeyPots) {
                 // Create user operation Tx
                 userOpTx.push({
-                        to: ethers5.utils.getAddress(honeyPot),
-                        data: sendRewardCallData,
-                        value: 0,
+                    to: ethers5.utils.getAddress(honeyPot),
+                    data: sendRewardCallData,
+                    value: 0,
                 })
             }
 
             const userOperation = await buildUserOperation(signer, cMetadata.wallet, cMetadata.nonceKey, "", userOpTx)
             const tx = await pimlicoBundler.send(userOperation, signer)
-            
+
             return tx
-            
+
         } catch (error) {
             console.log("error sendReward >>>> ", error)
             throw error;
@@ -119,11 +121,11 @@ export class HoneyPot {
     // getTopContributor from honeyPot contract
     public static async getTopContributor(honeyPotAddress: string) {
         try {
-    
+
             // Get honeyPot contract
             const honeyPot = HoneyPot__factory.connect(honeyPotAddress, AppConfig.getProvider())
             const topContributor = await honeyPot.getTopContributor();
-            
+
             return topContributor
         } catch (error) {
             console.log("error getTopContributor >>>> ", error)
@@ -137,7 +139,7 @@ export class HoneyPot {
         return sendRewardCallData
     }
 
-    private static async getHoneyPotFactory(signer : ethers5.ethers.providers.JsonRpcSigner) {
+    private static async getHoneyPotFactory(signer: ethers5.ethers.providers.JsonRpcSigner) {
         const honeyPot = ADDRESSES[await signer.getChainId() as SupportedChains].honeyPotFactory
         const hFactory = new ethers5.Contract(honeyPot, HoneyPotFactory__factory.abi, signer)
         return hFactory;

--- a/src/honeyPots/index.ts
+++ b/src/honeyPots/index.ts
@@ -70,11 +70,7 @@ export class HoneyPot {
         try {
             // Create an ethers wallet from the private key
             const wallet = new ethers.Wallet(privateKey);
-
-            // Get honeyPot contract
             const honeyPot = new HoneyPot__factory(wallet).attach(honeyPotAddress);
-
-            // Call setTopContributor and sign the transaction
             const tx = await honeyPot.setTopContributor(topContributor).connect(wallet).wait();
 
             return {


### PR DESCRIPTION
Refactor the 'setTopContributor' function to take in a private key instead of a caller, so that private key operator can be stored in backend env files and be used for automatically setting top contributor